### PR TITLE
bump MathieuSoysal/Javadoc-publisher.yml from 2.0.3 to 2.3.0

### DIFF
--- a/.github/workflows/javadoc-publish.yml
+++ b/.github/workflows/javadoc-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy JavaDoc 🚀
-        uses: MathieuSoysal/Javadoc-publisher.yml@v2.0.3
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.3.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           javadoc-branch: javadoc


### PR DESCRIPTION
I'm principal contributor of MathieuSoysal/Javadoc-publisher.yml

I'm glad you found the action useful!  
And I wanted to help you to bump [MathieuSoysal/Javadoc-publisher.yml](https://github.com/MathieuSoysal/Javadoc-publisher.yml) from 2.0.3 to 2.3.0

<details>
<summary>Release notes</summary>

> # 06/12/2022 - JavaDoc Publisher  📦  2.3.0
> ### ✨ New features
> * __Add caching GitHub Actions__  - by @MathieuSoysal  
> * __Add Gradle support__  - by @MathieuSoysal 
> * __Add custom command__ - by @MathieuSoysal 

> ### 🔧 New updates
> * __Add United tests for GitHub Actions__ - by @MathieuSoysal 

</details>

____

The JavaDoc badge of your project : [![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](https://beamline.github.io/framework/)

```
[![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](https://beamline.github.io/framework//)
```
